### PR TITLE
updateUser mutation needs to check for dup username and dup email

### DIFF
--- a/src/functions/resolvers/LeagueResolver.ts
+++ b/src/functions/resolvers/LeagueResolver.ts
@@ -46,8 +46,7 @@ export class LeagueResolver {
             league = await LeagueRepository.create(entity)
             return league
         } catch (e) {
-            console.log(e.message)
-            throw new TypeError()
+            throw new Error(e.message)
         }
     }
     @Mutation(() => League)
@@ -66,8 +65,7 @@ export class LeagueResolver {
         try {
             const leagueToUpdate = await LeagueRepository.findById(id)
             if (!leagueToUpdate) {
-                console.log('LeagueId is invalid')
-                throw new TypeError('LeagueId is invalid')
+                throw new Error('LeagueId is invalid')
             }
             leagueToUpdate.name = name
             leagueToUpdate.ownerId = ownerId
@@ -76,13 +74,16 @@ export class LeagueResolver {
             league = await LeagueRepository.update(leagueToUpdate)
             return league
         } catch (e) {
-            console.log(e.message)
-            throw new TypeError()
+            throw new Error(e.message)
         }
     }
     @Mutation(() => Boolean)
-    async removeSingleLeague(@Arg('id') id: string): Promise<boolean> {
-        await LeagueRepository.delete(id)
-        return true
+    async removeSingleLeague(@Arg('id') id: string): Promise<Boolean> {
+        try {
+            await LeagueRepository.delete(id)
+            return true
+        } catch (e) {
+            throw new Error(e.message)
+        }
     }
 }

--- a/src/functions/resolvers/SeasonResolver.ts
+++ b/src/functions/resolvers/SeasonResolver.ts
@@ -45,8 +45,7 @@ export class SeasonResolver {
         try {
             season = await SeasonRepository.create(entity)
         } catch (e) {
-            console.log(e.message)
-            return season
+            throw new Error(e.message)
         }
 
         return season
@@ -69,8 +68,7 @@ export class SeasonResolver {
         try {
             const seasonToUpdate = await SeasonRepository.findById(id)
             if (!seasonToUpdate) {
-                console.log('SeasonId is invalid')
-                throw new TypeError('SeasonId is invalid')
+                throw new Error('SeasonId is invalid')
             }
             seasonToUpdate.name = name
             seasonToUpdate.startDate = startDate
@@ -80,13 +78,17 @@ export class SeasonResolver {
             season = await SeasonRepository.update(seasonToUpdate)
             return season
         } catch (e) {
-            console.log(e.message)
-            throw new TypeError()
+            throw new Error(e.message)
         }
     }
     @Mutation(() => Boolean)
     async removeSingleSeason(@Arg('id') id: string): Promise<boolean> {
-        await SeasonRepository.delete(id)
+        try {
+            await SeasonRepository.delete(id)
+        } catch (e) {
+            throw new Error(e.message)
+        }
+
         return true
     }
 }

--- a/src/functions/resolvers/UserResolver.ts
+++ b/src/functions/resolvers/UserResolver.ts
@@ -112,7 +112,11 @@ export class UserResolver {
 
     @Mutation(() => Boolean)
     async removeSingleUser(@Arg('id') id: string): Promise<boolean> {
-        await UserRepository.delete(id)
-        return true
+        try {
+            await UserRepository.delete(id)
+            return true
+        } catch (e) {
+            throw new Error(e.message)
+        }
     }
 }

--- a/src/functions/resolvers/UserResolver.ts
+++ b/src/functions/resolvers/UserResolver.ts
@@ -15,6 +15,15 @@ export class UserResolver {
         return await UserRepository.find()
     }
 
+    async isDuplicateUsernameForLoggedInUser(id: string, username: string): Promise<Boolean> {
+        const possibleDupUsernames = await UserRepository.whereEqualTo('username', username).find()
+        return possibleDupUsernames.filter((possibleDup: User) => possibleDup.id !== id).length > 0
+    }
+
+    async isDuplicateEmailForLoggedInUser(@Arg('id') id: string, @Arg('email') email: string): Promise<Boolean> {
+        const possibleDupUsernames = await UserRepository.whereEqualTo('email', email).find()
+        return possibleDupUsernames.filter((possibleDup: User) => possibleDup.id !== id).length > 0
+    }
     @Mutation(() => User)
     async createUser(
         @Arg('data', { validate: true })
@@ -49,22 +58,11 @@ export class UserResolver {
         const user = await UserRepository.create(entity)
         return user
     }
+
     @Mutation(() => User)
     async updateUser(
         @Arg('data', { validate: true })
-        {
-            id,
-            email,
-            firstName,
-            lastName,
-            profileImageName,
-            city,
-            state,
-            username,
-            zip,
-            loginProvider,
-            defaultAvatarThemeIndex,
-        }: UserUpdateInput
+        { id, email, firstName, lastName, profileImageName, city, state, username, zip }: UserUpdateInput
     ): Promise<User> {
         let user: User = {
             id: '',
@@ -85,15 +83,20 @@ export class UserResolver {
         try {
             const userToUpdate = await UserRepository.findById(id)
             if (!userToUpdate) {
-                console.log('UserId is invalid')
-                throw new TypeError('UserId is invalid')
+                throw new Error('UserId is invalid')
+            }
+            const isDuplicateUsername: Boolean = await this.isDuplicateUsernameForLoggedInUser(id, username)
+            if (isDuplicateUsername) {
+                throw new Error('This Username already exists')
+            }
+            const isDuplicateEmail: Boolean = await this.isDuplicateEmailForLoggedInUser(id, email)
+            if (isDuplicateEmail) {
+                throw new Error('The email provided is being used by another user')
             }
             userToUpdate.email = email
             userToUpdate.firstName = firstName
             userToUpdate.lastName = lastName
             userToUpdate.profileImageName = profileImageName || userToUpdate.profileImageName || ''
-            userToUpdate.loginProvider = loginProvider
-            userToUpdate.defaultAvatarThemeIndex = defaultAvatarThemeIndex || userToUpdate.defaultAvatarThemeIndex || 0
             userToUpdate.username = username
             userToUpdate.city = city || userToUpdate.city || ''
             userToUpdate.state = state || userToUpdate.state || ''
@@ -103,7 +106,7 @@ export class UserResolver {
             return user
         } catch (e) {
             console.log(e.message)
-            throw new TypeError()
+            throw new Error(e.message)
         }
     }
 

--- a/src/functions/resolvers/__tests__/UserResolver.test.ts
+++ b/src/functions/resolvers/__tests__/UserResolver.test.ts
@@ -11,6 +11,8 @@ const fixtureData = {
                     lastName: 'Simpson',
                     username: 'hsimpson',
                     email: 'hsimpson@springfieldpower.com',
+                    loginProvider: 'email',
+                    defaultAvatarThemeIndex: 0,
                 },
                 QUsewNSXhRJuoKZoqiqdgIDWHp2: {
                     id: 'QUsewNSXhRJuoKZoqiqdgIDWHp2',
@@ -18,6 +20,8 @@ const fixtureData = {
                     lastName: 'Simpson',
                     username: 'msimpson',
                     email: 'msimpson@springfield.net',
+                    loginProvider: 'google',
+                    defaultAvatarThemeIndex: 0,
                 },
             },
         },
@@ -139,8 +143,6 @@ describe('User Resolver', () => {
             lastName: 'Powell',
             email: 'hpowell@kompany.zone',
             username: 'hpowell',
-            defaultAvatarThemeIndex: 0,
-            loginProvider: 'email',
             profileImageName: '',
             city: '',
             state: '',
@@ -198,8 +200,6 @@ describe('User Resolver', () => {
             lastName: 'Powell',
             email: 'hpowell@kompany.zone',
             username: 'hpowell',
-            defaultAvatarThemeIndex: 0,
-            loginProvider: 'email',
             profileImageName: '',
             city: '',
             state: '',
@@ -218,8 +218,6 @@ describe('User Resolver', () => {
             lastName: user.lastName,
             email: user.email,
             username: user.username,
-            defaultAvatarThemeIndex: user.defaultAvatarThemeIndex,
-            loginProvider: user.loginProvider,
         })
     })
 

--- a/src/functions/resolvers/types/UserUpdateInput.ts
+++ b/src/functions/resolvers/types/UserUpdateInput.ts
@@ -8,10 +8,6 @@ export class UserUpdateInput implements Partial<User> {
     @Field(() => ID)
     id: string
 
-    @Field(() => Int)
-    @IsIn([0, 1, 2, 3])
-    defaultAvatarThemeIndex: number
-
     @Field({ nullable: false })
     @IsNotEmpty()
     @IsEmail()
@@ -25,17 +21,11 @@ export class UserUpdateInput implements Partial<User> {
     @Length(2, 20)
     lastName: string
 
-    @Field({ nullable: false })
-    @IsNotEmpty()
-    @IsIn(['email', 'google'])
-    loginProvider: string
-
     @Field({ nullable: true })
     profileImageName: string
 
     @Field({ nullable: false })
     @Length(2, 255)
-    @IsNotUsernameAlreadyExists({ message: 'Sorry, the username, $value has been taken.' })
     username: string
 
     @Field({ nullable: true })


### PR DESCRIPTION
cannot use the decorator because it does not take the logged in user into consideration.  So we manually check the database upon updateUser mutation.  Throws errors if necessary.